### PR TITLE
Fix kernel panic after otg disconnect

### DIFF
--- a/drivers/staging/prima/CORE/HDD/src/wlan_hdd_main.c
+++ b/drivers/staging/prima/CORE/HDD/src/wlan_hdd_main.c
@@ -12476,9 +12476,9 @@ void hdd_wlan_exit(hdd_context_t *pHddCtx)
    unregister_inetaddr_notifier(&pHddCtx->ipv4_notifier);
 
    // Unregister the Net Device Notifier
-   unregister_netdevice_notifier(&hdd_netdev_notifier);
+   //unregister_netdevice_notifier(&hdd_netdev_notifier);
    
-   hdd_stop_all_adapters( pHddCtx );
+   //hdd_stop_all_adapters( pHddCtx );
 
 #ifdef WLAN_BTAMP_FEATURE
    vosStatus = WLANBAP_Stop(pVosContext);
@@ -14283,6 +14283,7 @@ int hdd_wlan_startup(struct device *dev )
       goto err_unregister_pmops;
    }
 
+   /*
    // register net device notifier for device change notification
    ret = register_netdevice_notifier(&hdd_netdev_notifier);
 
@@ -14291,12 +14292,14 @@ int hdd_wlan_startup(struct device *dev )
       hddLog(VOS_TRACE_LEVEL_ERROR,"%s: register_netdevice_notifier failed",__func__);
       goto err_unregister_pmops;
    }
+   */
 
    //Initialize the BTC service
    if(btc_activate_service(pHddCtx) != 0)
    {
       hddLog(VOS_TRACE_LEVEL_FATAL,"%s: btc_activate_service failed",__func__);
-      goto err_reg_netdev;
+      //goto err_reg_netdev;
+      goto err_nl_srv;
    }
 
 #ifdef FEATURE_OEM_DATA_SUPPORT
@@ -14507,8 +14510,8 @@ err_oem_activate_service:
 err_btc_activate_service:
    btc_deactivate_service();
 
-err_reg_netdev:
-   unregister_netdevice_notifier(&hdd_netdev_notifier);
+//err_reg_netdev:
+//   unregister_netdevice_notifier(&hdd_netdev_notifier);
 
 err_unregister_pmops:
    hddDevTmUnregisterNotifyCallback(pHddCtx);


### PR DESCRIPTION
The default branch has a bug where the kernel panics after disconnecting the WiFi adapter (wlan1). This is a bug specific for our device, as it uses the Prima/Pronto drivers. 

My changes are based on the following example: https://github.com/jcadduono/nethunter_kernel_mako/commit/bda7cf4b08a04152a868e87b2f90070db6b88134